### PR TITLE
Minimize ECR storage cost for buy-lotto

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md
+
+[dhlottery.co.kr](https://www.dhlottery.co.kr)에서 로또를 자동으로 구매하는 봇입니다.
+
+### Requirements
+
+- Node.js 22
+- Docker
+- AWS CLI / aws-vault
+
+## Deployment
+
+1. Docker 이미지 빌드
+   ```bash
+   docker build --platform linux/amd64 --provenance=false -t buy-lotto buyLotto/
+   ```
+2. ECR 로그인
+   ```bash
+   aws-vault exec <profile> -- aws ecr get-login-password --region ap-northeast-2 \
+     | docker login --username AWS --password-stdin 084761792497.dkr.ecr.ap-northeast-2.amazonaws.com
+   ```
+3. 태그 및 ECR 푸시
+   ```bash
+   docker tag buy-lotto:latest 084761792497.dkr.ecr.ap-northeast-2.amazonaws.com/buy-lotto:latest
+   docker push 084761792497.dkr.ecr.ap-northeast-2.amazonaws.com/buy-lotto:latest
+   ```
+4. Lambda 함수 코드 업데이트
+   ```bash
+   aws-vault exec <profile> -- aws lambda update-function-code \
+     --function-name buy-lotto \
+     --image-uri 084761792497.dkr.ecr.ap-northeast-2.amazonaws.com/buy-lotto:latest \
+     --region ap-northeast-2
+   ```
+5. ECR 수명주기 정책 적용
+   ```bash
+   aws-vault exec <profile> -- aws ecr put-lifecycle-policy \
+     --repository-name buy-lotto \
+     --lifecycle-policy-text file://buyLotto/ecr-lifecycle-policy.json \
+     --region ap-northeast-2
+   ```
+
+### Lambda 수동 호출
+
+```bash
+aws-vault exec <profile> -- aws lambda invoke \
+  --function-name buy-lotto \
+  --region ap-northeast-2 \
+  /tmp/lambda-output.json && cat /tmp/lambda-output.json
+```
+
+### CloudWatch 로그 확인
+
+```bash
+# 최근 로그 스트림 조회
+aws-vault exec <profile> -- aws logs describe-log-streams \
+  --log-group-name /aws/lambda/buy-lotto \
+  --order-by LastEventTime --descending --limit 3 \
+  --region ap-northeast-2
+
+# 최근 로그 이벤트 조회
+aws-vault exec <profile> -- aws logs get-log-events \
+  --log-group-name /aws/lambda/buy-lotto \
+  --log-stream-name "<log-stream-name>" \
+  --limit 50 \
+  --region ap-northeast-2
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,75 @@
-# bots-with-lambda
-aws lambda 위에서 돌리기 위한 bot 들
+# bots-on-lambda
 
-### 유의사항
-- layer 를 만들 때 "nodejs/node_modules" path rule 을 지켜야한다.
+AWS Lambda 위에서 돌아가는 봇 모음. 현재 주요 봇은 **buyLotto**(로또 자동 구매)입니다.
 
+## 프로젝트 구조
+
+```
+bots-on-lambda/
+├── buyLotto/          # 로또 자동 구매 봇
+│   ├── Dockerfile
+│   ├── index.js
+│   ├── package.json
+│   ├── ecr-lifecycle-policy.json
+│   └── serverless.yml
+└── usedSthCrawler/    # (미사용) 중고 크롤러
+```
+
+## buyLotto
+
+[dhlottery.co.kr](https://www.dhlottery.co.kr)에서 로또를 자동으로 구매하는 봇입니다.
+
+- **Playwright + Chromium**으로 브라우저 자동화
+- 매주 **금요일 20:00 KST** (UTC 11:00) EventBridge 스케줄로 자동 실행
+- 자동번호 5장 구매 후 **Slack 웹훅**으로 결과 알림
+
+## 사전 요구사항
+
+- Node.js 22
+- Docker
+- AWS CLI
+- aws-vault
+
+## 환경변수
+
+| 변수 | 설명 |
+|---|---|
+| `LOTTO_ID` | dhlottery.co.kr 로그인 아이디 |
+| `LOTTO_PW` | dhlottery.co.kr 로그인 비밀번호 |
+| `SLACK_WEBHOOK_URL` | Slack Incoming Webhook URL |
+
+## 빌드 및 배포
+
+```bash
+# 1. Docker 이미지 빌드
+docker build --platform linux/amd64 --provenance=false -t buy-lotto buyLotto/
+
+# 2. ECR 로그인
+aws-vault exec <profile> -- aws ecr get-login-password --region ap-northeast-2 \
+  | docker login --username AWS --password-stdin 084761792497.dkr.ecr.ap-northeast-2.amazonaws.com
+
+# 3. 태그 및 푸시
+docker tag buy-lotto:latest 084761792497.dkr.ecr.ap-northeast-2.amazonaws.com/buy-lotto:latest
+docker push 084761792497.dkr.ecr.ap-northeast-2.amazonaws.com/buy-lotto:latest
+
+# 4. Lambda 함수 업데이트
+aws-vault exec <profile> -- aws lambda update-function-code \
+  --function-name buy-lotto \
+  --image-uri 084761792497.dkr.ecr.ap-northeast-2.amazonaws.com/buy-lotto:latest \
+  --region ap-northeast-2
+
+# 5. ECR 수명주기 정책 적용 (오래된 이미지 자동 정리)
+aws-vault exec <profile> -- aws ecr put-lifecycle-policy \
+  --repository-name buy-lotto \
+  --lifecycle-policy-text file://buyLotto/ecr-lifecycle-policy.json \
+  --region ap-northeast-2
+```
+
+## 로컬 테스트
+
+```bash
+cd buyLotto
+npm run local
+```
+
+환경변수(`LOTTO_ID`, `LOTTO_PW`, `SLACK_WEBHOOK_URL`)를 미리 설정해야 합니다.

--- a/buyLotto/.dockerignore
+++ b/buyLotto/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+.DS_Store
+*.md
+.serverless

--- a/buyLotto/Dockerfile
+++ b/buyLotto/Dockerfile
@@ -1,21 +1,33 @@
-FROM mcr.microsoft.com/playwright:v1.57.0-jammy
+FROM ubuntu:22.04 AS builder
 
-# Install build tools and upgrade Node.js to 22
-RUN apt-get update && apt-get install -y cmake curl xz-utils build-essential && \
+RUN apt-get update && \
+    apt-get install -y curl cmake build-essential && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-
 COPY package*.json ./
 RUN npm install
 
-COPY . .
+FROM ubuntu:22.04
 
-# AWS Lambda Runtime Interface Emulator for local testing
-ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/local/bin/aws-lambda-rie
-RUN chmod +x /usr/local/bin/aws-lambda-rie
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
+
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY package*.json ./
+# Install only Chromium browser and its system dependencies
+RUN npx playwright install --with-deps chromium && \
+    chmod -R o+rx /opt/pw-browsers
+
+COPY . .
 
 ENTRYPOINT ["/usr/bin/npx", "aws-lambda-ric"]
 CMD ["/app/index.handler"]

--- a/buyLotto/ecr-lifecycle-policy.json
+++ b/buyLotto/ecr-lifecycle-policy.json
@@ -1,0 +1,30 @@
+{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Expire untagged images after 1 day",
+      "selection": {
+        "tagStatus": "untagged",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 1
+      },
+      "action": {
+        "type": "expire"
+      }
+    },
+    {
+      "rulePriority": 2,
+      "description": "Keep only 1 tagged image",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPrefixList": ["v", "latest"],
+        "countType": "imageCountMoreThan",
+        "countNumber": 1
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Replace full Playwright base image (`mcr.microsoft.com/playwright:v1.57.0-jammy`) with `ubuntu:22.04` + Chromium-only install, reducing image size from **986 MB → 548 MB** (44% reduction)
- Use multi-stage Docker build to keep `cmake`/`build-essential` out of the runtime image
- Add ECR lifecycle policy (`ecr-lifecycle-policy.json`) to expire untagged images after 1 day and keep only 1 tagged image
- Add `.dockerignore` to exclude `node_modules`, `.git`, and other unnecessary files from build context

## Test plan
- [x] Built image locally: `docker build --platform linux/amd64 --provenance=false -t buy-lotto buyLotto/`
- [x] Verified image size: 548 MB (down from 986 MB)
- [x] Applied ECR lifecycle policy via `aws ecr put-lifecycle-policy`
- [x] Pushed to ECR and updated Lambda function
- [x] Invoked Lambda — Chromium launches correctly (timeout is due to lotto site purchase hours, not image issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)